### PR TITLE
Added background in reading view, updated to 1.2.0 and synced package-lock.json version with package.json and manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "background-image",
 	"name": "Background Image",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"minAppVersion": "0.15.0",
 	"description": "This allows you to specify a remote URL as the background image, and a few settings to tweak the experience.",
 	"author": "shmolf",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-editor-background",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-editor-background",
-			"version": "1.0.0",
+			"version": "1.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-editor-background",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "This allows you to specify a remote URL as the background image, and an opacity percentage for the background image.",
 	"main": "main.js",
 	"scripts": {

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,19 @@
+.markdown-reading-view:before,
 .cm-editor:before {
-    content: '';
-    background-blend-mode: overlay;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: cover;
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    background-image: var(--obsidian-editor-background-image);
-    opacity: var(--obsidian-editor-background-opacity);
-    filter: var(--obsidian-editor-background-bluriness);
+	content: "";
+	background-blend-mode: overlay;
+	background-repeat: no-repeat;
+	background-position: center;
+	background-size: cover;
+	width: 100%;
+	height: 100%;
+	position: absolute;
+	background-image: var(--obsidian-editor-background-image);
+	opacity: var(--obsidian-editor-background-opacity);
+	filter: var(--obsidian-editor-background-bluriness);
 }
 
+.markdown-reading-view,
 .cm-editor .cm-contentContainer {
-    background: var(--obsidian-editor-background-input-contrast);
+	background: var(--obsidian-editor-background-input-contrast);
 }


### PR DESCRIPTION
# Changes

- Fixed #13 by adding the same CSS to `.markdown-reading-view` and `.markdown-reading-view:before`
- Synced versions between `package.json`, `manifest.json` and `package-lock,json`
- Upgraded to 1.2.0 since a new feature has been implemented

# Preview:
Reading mode:

![image](https://github.com/shmolf/obsidian-editor-background/assets/82510639/7fbb6959-b942-4e6a-b1fd-dd56c592c2a2)

Source mode:
![image](https://github.com/shmolf/obsidian-editor-background/assets/82510639/479d04f2-95c7-4fe6-9da5-07b2a6424d26)

Live preview:
![image](https://github.com/shmolf/obsidian-editor-background/assets/82510639/5ebda8b6-fe7c-4ae4-9c99-421b5bf200e3)


Image used: [https://c4.wallpaperflare.com/wallpaper/708/141/138/anime-anime-girls-technology-software-arch-linux-hd-wallpaper-preview.jpg](https://c4.wallpaperflare.com/wallpaper/708/141/138/anime-anime-girls-technology-software-arch-linux-hd-wallpaper-preview.jpg)
# Testing

I have tested it on my machine, running Windows 11 in a 1080x1920 px monitor. I have not tested it on other devices

Obsidian version: 1.5.3 (latest)

Installer version: 1.4.16 (latest)

### Plugins used:
`.obsidian/community-plugins.json`:
```js
[
  "obsidian-admonition",
  "calendar",
  "better-word-count",
  "dataview",
  "obsidian-desmos",
  "cm-editor-syntax-highlight-obsidian",
  "obsidian-linter",
  "quick-latex",
  "templater-obsidian",
  "waypoint",
  "lapel",
  "homepage",
  "obsidian-style-settings",
  "recent-files-obsidian",
  "obsidian-icon-folder",
  "table-editor-obsidian",
  "background-image"
]
```

`core-plugins.json`:
```js
[
  "file-explorer",
  "global-search",
  "switcher",
  "graph",
  "backlink",
  "canvas",
  "outgoing-link",
  "tag-pane",
  "properties",
  "page-preview",
  "daily-notes",
  "command-palette",
  "editor-status",
  "bookmarks",
  "outline",
  "file-recovery",
  "sync"
]
```